### PR TITLE
Harmony palette fixes

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,7 +39,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -8,7 +8,10 @@ import java.util.ArrayList;
 import static android.graphics.Color.RGBToHSV;
 import static com.harmony.livecolor.UsefulFunctions.convertHSVtoRGB;
 
-//Contains functions for generating colors for palettes based on a given color.
+/**
+ * Contains functions for generating colors for palettes based on a given color for HarmonyInfoActivity.java.
+ * @author Dustin
+ */
 public class HarmonyGenerator {
     //Each color[] should be the hsv like what is returned by the rest of the functions in this file.
     public static ArrayList<MyColor> colorsToMyColors(float[][] colors, int numberOfColors){

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -132,7 +132,6 @@ public class HarmonyGenerator {
     public static float[][] monochromaticScheme(float hue, float saturation, float value, float percent, int numberOfColors, boolean skipRedundantColors){
         //Hue, saturation, value. Three numbers to store in each array.
         final int numberOfComponents = 3;
-        float[][] monochromaticColors = new float[numberOfColors][numberOfComponents];
         float distanceFromRight = 1-value;
         float distanceFromLeft = value;
         final int numberOfColorsLeft = (int) (numberOfColors / 2);
@@ -143,14 +142,29 @@ public class HarmonyGenerator {
         if(differenceLeft <= 0.01){
             leftRedundant = true;
         }
-        boolean shouldNotSkipLeft = !skipRedundantColors || !leftRedundant;
+        boolean shouldNotSkipLeft = !(skipRedundantColors && leftRedundant);
         float differenceRight = distanceFromRight * percent / numberOfColorsRight;
         boolean rightRedundant = false;
         if(differenceRight <= 0.01){
             rightRedundant = true;
         }
-        boolean shouldNotSkipRight = !skipRedundantColors || !rightRedundant;
-        Log.d("S4US4", "v="+value+" dfl="+distanceFromLeft+" dl="+differenceLeft + " dfr="+distanceFromRight+" dr="+differenceRight);
+        boolean shouldNotSkipRight = !(skipRedundantColors && rightRedundant);
+
+        int resultNumberOfColors = 1;
+        if(!skipRedundantColors){
+            resultNumberOfColors = numberOfColors;
+        }
+        if(skipRedundantColors && shouldNotSkipRight){
+            resultNumberOfColors += (int) numberOfColors/2;
+        }
+        if(skipRedundantColors && shouldNotSkipLeft){
+            resultNumberOfColors += (int) numberOfColors/2;
+        }
+        float[][] monochromaticColors = new float[resultNumberOfColors][numberOfComponents];
+        Log.d("S4US4", "v="+value+" dfl="+distanceFromLeft+" dl="+differenceLeft
+                + " dfr="+distanceFromRight+" dr="+differenceRight +" lR="+leftRedundant +" rR="+rightRedundant
+                + " snsl=" + shouldNotSkipLeft + " snsr=" + shouldNotSkipRight + " rnc=" + resultNumberOfColors
+        );
         int middleIndex = numberOfColors / 2;
         for(int i = 0; i < numberOfColors; ++i){
             float monoValue;
@@ -162,7 +176,7 @@ public class HarmonyGenerator {
                 monoValue = value + (differenceLeft * numberOfColorsLeftFromMiddle);
                 Log.d("S4US4", "Calculated mono color  left "+numberOfColorsLeftFromMiddle
                         +" : "+monoValue);
-            } else if (shouldNotSkipRight) {
+            } else if (i == middleIndex || (i < middleIndex && shouldNotSkipRight)) {
                 int numberOfColorsRightFromMiddle = i - middleIndex;
                 monoValue = value - (differenceRight * numberOfColorsRightFromMiddle);
                 Log.d("S4US4", "Calculated mono color right "+numberOfColorsRightFromMiddle

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -24,9 +24,10 @@ public class HarmonyGenerator {
         String hex = hsvToStringHex(color);
         String rgb = hsvToStringRgb(color);
         String hsv = hsvToStringHsv(color);
-        //String colorName = ColorNameGetterCSV.getName(hex);
-        String colorName = "";
         //TODO the name works now, but opening harmonies takes a few seconds because it does it for all palettes at once.
+        //String colorName = ColorNameGetterCSV.getName(hex);
+        //Easiest fix: just use a blank name and let them go to color info if they want a name.
+        String colorName = "";
         MyColor colorObj = new MyColor(""+id, colorName, hex, rgb, hsv);
         return colorObj;
     }

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -189,7 +189,13 @@ public class HarmonyGenerator {
             //monoValue = checkValueForOverflow(monoValue);
 
             float[] color = new float[] {hue, saturation, monoValue};
-            monochromaticColors[i] = color;
+            int index = i;
+            //If we skipped the real left side ("right" side according mislabeled junk) then we need to adjust the index
+            if(i >= middleIndex && !shouldNotSkipRight){
+                int numberOfColorsFromMiddle = i - middleIndex;
+                index = numberOfColorsFromMiddle;
+            }
+            monochromaticColors[index] = color;
         }
         return monochromaticColors;
     }

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -129,7 +129,7 @@ public class HarmonyGenerator {
     //numberOfColors should always be odd, the middle value is the color you passed in.
     //TODO how should we handle percent? Currently it does a percent of available space in each direction,
     //  meaning left and right colors are equally spaced with respect to their sides but not the opposite side.
-    public static float[][] monochromaticScheme(float hue, float saturation, float value, float percent, int numberOfColors){
+    public static float[][] monochromaticScheme(float hue, float saturation, float value, float percent, int numberOfColors, boolean skipRedundantColors){
         //Hue, saturation, value. Three numbers to store in each array.
         final int numberOfComponents = 3;
         float[][] monochromaticColors = new float[numberOfColors][numberOfComponents];
@@ -139,7 +139,17 @@ public class HarmonyGenerator {
         final int numberOfColorsRight = numberOfColorsLeft;
         //How much spacing between each color.
         float differenceLeft = distanceFromLeft * percent / numberOfColorsLeft;
+        boolean leftRedundant = false;
+        if(differenceLeft <= 0.01){
+            leftRedundant = true;
+        }
+        boolean shouldNotSkipLeft = !skipRedundantColors || !leftRedundant;
         float differenceRight = distanceFromRight * percent / numberOfColorsRight;
+        boolean rightRedundant = false;
+        if(differenceRight <= 0.01){
+            rightRedundant = true;
+        }
+        boolean shouldNotSkipRight = !skipRedundantColors || !rightRedundant;
         Log.d("S4US4", "v="+value+" dfl="+distanceFromLeft+" dl="+differenceLeft + " dfr="+distanceFromRight+" dr="+differenceRight);
         int middleIndex = numberOfColors / 2;
         for(int i = 0; i < numberOfColors; ++i){
@@ -147,16 +157,18 @@ public class HarmonyGenerator {
             //I actually messed up left and right, meant left to mean lighter, right to mean darker.
             //So this just does the reverse of what the names imply.
             //TODO cleanup
-            if(i > middleIndex){
+            if(i > middleIndex && shouldNotSkipLeft){
                 int numberOfColorsLeftFromMiddle = middleIndex - i;
                 monoValue = value + (differenceLeft * numberOfColorsLeftFromMiddle);
                 Log.d("S4US4", "Calculated mono color  left "+numberOfColorsLeftFromMiddle
                         +" : "+monoValue);
-            } else {
+            } else if (shouldNotSkipRight) {
                 int numberOfColorsRightFromMiddle = i - middleIndex;
                 monoValue = value - (differenceRight * numberOfColorsRightFromMiddle);
                 Log.d("S4US4", "Calculated mono color right "+numberOfColorsRightFromMiddle
                         +" : "+monoValue);
+            } else {
+                continue;
             }
 
             //An overflow would just be an error, right?

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -24,7 +24,8 @@ public class HarmonyGenerator {
         String hex = hsvToStringHex(color);
         String rgb = hsvToStringRgb(color);
         String hsv = hsvToStringHsv(color);
-        String colorName = ColorNameGetterCSV.getName(hex);
+        //String colorName = ColorNameGetterCSV.getName(hex);
+        String colorName = "";
         //TODO the name works now, but opening harmonies takes a few seconds because it does it for all palettes at once.
         MyColor colorObj = new MyColor(""+id, colorName, hex, rgb, hsv);
         return colorObj;
@@ -78,6 +79,16 @@ public class HarmonyGenerator {
         float complementHue = hue + 180;
         complementHue = checkHueForOverflow(complementHue);
         return complementHue;
+    }
+
+    //
+    public static float[][] complementScheme(float hue, float saturation, float value, int numberOfColors){
+        //Hue, saturation, value. Three numbers to store in each array.
+        final int numberOfComponents = 3;
+        float[][] colors = new float[numberOfColors][numberOfComponents];
+        colors[0] = new float[] {hue, saturation, value};
+        colors[1] = complement(hue, saturation, value);
+        return colors;
     }
 
     //numberOfColors should always be odd, the middle value is the color you passed in.
@@ -187,6 +198,7 @@ public class HarmonyGenerator {
         return resultColors;
     }
 
+    //TODO check this
     //Valid hue values are 0 thru 360, inclusive.
     private static float checkHueForOverflow(float hue){
         if(hue > 360){

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -168,6 +168,7 @@ public class HarmonyGenerator {
         return monochromaticColors;
     }
 
+    //TODO refactor, this is actually split-complementary.
     public static float[][] triadicScheme(float hue, float saturation, float value, int degrees, int numberOfColors){
         //Hue, saturation, value. Three numbers to store in each array.
         final int numberOfComponents = 3;

--- a/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyGenerator.java
@@ -232,13 +232,14 @@ public class HarmonyGenerator {
         return resultColors;
     }
 
-    //TODO check this
-    //Valid hue values are 0 thru 360, inclusive.
+    //Note that 0 and 360 are the same. If they go to 361, they loop around to 1, not 0.
+    final static int MAX_HUE_DEGREES = 360;
+    final static int MIN_HUE_DEGREES = 0;
     private static float checkHueForOverflow(float hue){
-        if(hue > 360){
-            return hue - 361;
-        } else if(hue < 0){
-            return hue + 361;
+        if(hue > MAX_HUE_DEGREES){
+            return hue - MAX_HUE_DEGREES;
+        } else if(hue < MIN_HUE_DEGREES){
+            return hue + MAX_HUE_DEGREES;
         } else {
             return hue;
         }

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -12,6 +12,10 @@ import android.widget.ImageButton;
 
 import java.util.ArrayList;
 
+/**
+ * This class shows harmonies for a chosen color. Accessed through a button on ColorInfoActivity.
+ * @author Dustin
+ */
 public class HarmonyInfoActivity extends AppCompatActivity {
 
     //In case we want delete option

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -77,10 +77,15 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         // also the edit button when you select a palette does nothing.
 
         //TODO probably remove this, it's useful for testing though.
-        float[][] testBasicColor = new float[][] {new float[] {hue, saturation, value}};
-        ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 1);
-        MyPalette testBasicColorPalette = new MyPalette("1", "Original color", testBasicColorMyColors);
-        paletteList.add(testBasicColorPalette);
+//        float[][] testBasicColor = new float[][] {new float[] {hue, saturation, value}};
+//        ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 1);
+//        MyPalette testBasicColorPalette = new MyPalette("1", "Original color", testBasicColorMyColors);
+//        paletteList.add(testBasicColorPalette);
+        //Lets show the chosen color and its complement
+        float[][] testBasicColor = HarmonyGenerator.complementScheme(hue, saturation, value, 2);
+        ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 2);
+        MyPalette testBasicPalette = new MyPalette("1", "Analogous", testBasicColorMyColors);
+        paletteList.add(testBasicPalette);
 
         //Testing getting the analogous colors each a # of degrees to each side of the given color.
         float[][] testAnalogous = HarmonyGenerator.analogousScheme(hue, saturation, value, 20, 5);

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -103,7 +103,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
 
         //TODO to fix this might be harder. Generate more of the other lightness?
         //Testing getting the monochromatic colors to each side of the given color based on percent.
-        float[][] testMonochromatic = HarmonyGenerator.monochromaticScheme(hue, saturation, value, (float) 0.50, 5);
+        float[][] testMonochromatic = HarmonyGenerator.monochromaticScheme(hue, saturation, value, (float) 0.50, 5, true);
         ArrayList<MyColor> testMonochromaticMyColors = HarmonyGenerator.colorsToMyColors(testMonochromatic, 5);
         MyPalette testMonochromaticPalette = new MyPalette("2", "Monochromatic", testMonochromaticMyColors);
         paletteList.add(testMonochromaticPalette);

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -104,7 +104,8 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         //TODO to fix this might be harder. Generate more of the other lightness?
         //Testing getting the monochromatic colors to each side of the given color based on percent.
         float[][] testMonochromatic = HarmonyGenerator.monochromaticScheme(hue, saturation, value, (float) 0.50, 5, true);
-        ArrayList<MyColor> testMonochromaticMyColors = HarmonyGenerator.colorsToMyColors(testMonochromatic, 5);
+        int actualNumberOfColors = testMonochromatic.length;
+        ArrayList<MyColor> testMonochromaticMyColors = HarmonyGenerator.colorsToMyColors(testMonochromatic, actualNumberOfColors);
         MyPalette testMonochromaticPalette = new MyPalette("2", "Monochromatic", testMonochromaticMyColors);
         paletteList.add(testMonochromaticPalette);
 

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -101,7 +101,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
             paletteList.add(testBasicColorPalette);
         }
 
-        //TODO to fix this might be harder. Generate more of the other lightness?
+        //Changed the function to have parameter skipRedundantColors. If true, the returned list might be missing some entries for one side (won't get extra black when it's already black, etc).
         //Testing getting the monochromatic colors to each side of the given color based on percent.
         float[][] testMonochromatic = HarmonyGenerator.monochromaticScheme(hue, saturation, value, (float) 0.50, 5, true);
         int actualNumberOfColors = testMonochromatic.length;
@@ -128,6 +128,8 @@ public class HarmonyInfoActivity extends AppCompatActivity {
             MyPalette testEvenEvenSpacedPalette = new MyPalette("5", "Four evenly spaced hues", testEvenEvenSpacedMyColors);
             paletteList.add(testEvenEvenSpacedPalette);
         }
+
+        //Now that we have the palettes, we can add names asynchronously?
     }
 
     public void initRecycler(){

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -76,46 +76,57 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         //Note: fragment_palettes.xml limits the number of colors displayed per palette on the menu to 10.
         // also the edit button when you select a palette does nothing.
 
-        //TODO probably remove this, it's useful for testing though.
-//        float[][] testBasicColor = new float[][] {new float[] {hue, saturation, value}};
-//        ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 1);
-//        MyPalette testBasicColorPalette = new MyPalette("1", "Original color", testBasicColorMyColors);
-//        paletteList.add(testBasicColorPalette);
-        //Lets show the chosen color and its complement
-        float[][] testBasicColor = HarmonyGenerator.complementScheme(hue, saturation, value, 2);
-        ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 2);
-        MyPalette testBasicPalette = new MyPalette("1", "Color & Complement", testBasicColorMyColors);
-        paletteList.add(testBasicPalette);
+        //I'm not sure how to fix hue based color scheme for black/white.
+        //So if it's super light/dark I'll just not generate them.
+        float valueTooMonotonous = (float) 0.01;
 
-        //Testing getting the analogous colors each a # of degrees to each side of the given color.
-        float[][] testAnalogous = HarmonyGenerator.analogousScheme(hue, saturation, value, 20, 5);
-        ArrayList<MyColor> testAnalogousMyColors = HarmonyGenerator.colorsToMyColors(testAnalogous, 5);
-        MyPalette testAnalogousPalette = new MyPalette("1", "Analogous", testAnalogousMyColors);
-        paletteList.add(testAnalogousPalette);
+        //Check if it's in the range [0.01..0.99] inclusive
+        if(1 - valueTooMonotonous >= value && valueTooMonotonous <= value) {
+            //Color & Complement
+            float[][] testBasicColor = HarmonyGenerator.complementScheme(hue, saturation, value, 2);
+            ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 2);
+            MyPalette testBasicPalette = new MyPalette("1", "Color & Complement", testBasicColorMyColors);
+            paletteList.add(testBasicPalette);
 
+            //Testing getting the analogous colors each a # of degrees to each side of the given color.
+            float[][] testAnalogous = HarmonyGenerator.analogousScheme(hue, saturation, value, 20, 5);
+            ArrayList<MyColor> testAnalogousMyColors = HarmonyGenerator.colorsToMyColors(testAnalogous, 5);
+            MyPalette testAnalogousPalette = new MyPalette("1", "Analogous", testAnalogousMyColors);
+            paletteList.add(testAnalogousPalette);
+        } else {
+            //Color with no complement
+            float[][] testBasicColor = new float[][] {new float[] {hue, saturation, value}};
+            ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 1);
+            MyPalette testBasicColorPalette = new MyPalette("1", "Color", testBasicColorMyColors);
+            paletteList.add(testBasicColorPalette);
+        }
+
+        //TODO to fix this might be harder. Generate more of the other lightness?
         //Testing getting the monochromatic colors to each side of the given color based on percent.
         float[][] testMonochromatic = HarmonyGenerator.monochromaticScheme(hue, saturation, value, (float) 0.50, 5);
         ArrayList<MyColor> testMonochromaticMyColors = HarmonyGenerator.colorsToMyColors(testMonochromatic, 5);
         MyPalette testMonochromaticPalette = new MyPalette("2", "Monochromatic", testMonochromaticMyColors);
         paletteList.add(testMonochromaticPalette);
 
-        //TODO (refactor) I may have misunderstood triadic. I can just use the evenly spaced for that. This is Split-Complementary.
-        float[][] testTriadic = HarmonyGenerator.triadicScheme(hue, saturation, value, 20, 3);
-        ArrayList<MyColor> testTriadicMyColors = HarmonyGenerator.colorsToMyColors(testTriadic, 3);
-        MyPalette testTriadicPalette = new MyPalette("3", "Split-Complementary", testTriadicMyColors);
-        paletteList.add(testTriadicPalette);
+        if(1 - valueTooMonotonous >= value && valueTooMonotonous <= value) {
+            //TODO (refactor) I may have misunderstood triadic. I can just use the evenly spaced for that. This is Split-Complementary.
+            float[][] testTriadic = HarmonyGenerator.triadicScheme(hue, saturation, value, 20, 3);
+            ArrayList<MyColor> testTriadicMyColors = HarmonyGenerator.colorsToMyColors(testTriadic, 3);
+            MyPalette testTriadicPalette = new MyPalette("3", "Split-Complementary", testTriadicMyColors);
+            paletteList.add(testTriadicPalette);
 
-        //Testing getting some colors spaced evenly on the color wheel
-        float[][] testOddEvenSpaced = HarmonyGenerator.evenlySpacedScheme(hue, saturation, value, 3);
-        ArrayList<MyColor> testOddEvenSpacedMyColors = HarmonyGenerator.colorsToMyColors(testOddEvenSpaced, 3);
-        MyPalette testOddEvenSpacedPalette = new MyPalette("4", "Three evenly spaced hues", testOddEvenSpacedMyColors);
-        paletteList.add(testOddEvenSpacedPalette);
+            //Testing getting some colors spaced evenly on the color wheel
+            float[][] testOddEvenSpaced = HarmonyGenerator.evenlySpacedScheme(hue, saturation, value, 3);
+            ArrayList<MyColor> testOddEvenSpacedMyColors = HarmonyGenerator.colorsToMyColors(testOddEvenSpaced, 3);
+            MyPalette testOddEvenSpacedPalette = new MyPalette("4", "Three evenly spaced hues", testOddEvenSpacedMyColors);
+            paletteList.add(testOddEvenSpacedPalette);
 
-        //Testing getting some colors spaced evenly on the color wheel
-        float[][] testEvenEvenSpaced = HarmonyGenerator.evenlySpacedScheme(hue, saturation, value, 4);
-        ArrayList<MyColor> testEvenEvenSpacedMyColors = HarmonyGenerator.colorsToMyColors(testEvenEvenSpaced, 4);
-        MyPalette testEvenEvenSpacedPalette = new MyPalette("5", "Four evenly spaced hues", testEvenEvenSpacedMyColors);
-        paletteList.add(testEvenEvenSpacedPalette);
+            //Testing getting some colors spaced evenly on the color wheel
+            float[][] testEvenEvenSpaced = HarmonyGenerator.evenlySpacedScheme(hue, saturation, value, 4);
+            ArrayList<MyColor> testEvenEvenSpacedMyColors = HarmonyGenerator.colorsToMyColors(testEvenEvenSpaced, 4);
+            MyPalette testEvenEvenSpacedPalette = new MyPalette("5", "Four evenly spaced hues", testEvenEvenSpacedMyColors);
+            paletteList.add(testEvenEvenSpacedPalette);
+        }
     }
 
     public void initRecycler(){

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -129,12 +129,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
             paletteList.add(testEvenEvenSpacedPalette);
         }
 
-        //Now that we have the palettes, we can add names asynchronously?
-        //Doesn't work in our version of Java
-//        Thread newThread = new Thread(() -> {
-//            Log.d("Harmony", "Test thread");
-//        });
-//        newThread.start();
+        //Now that we have the palettes, we can add names asynchronously.
         Log.d("Harmony palettes", "Test before");
         Thread t = new HarmonyPaletteDelayedNames(paletteList);
         t.start();

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -136,7 +136,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
 //        });
 //        newThread.start();
         Log.d("Harmony palettes", "Test before");
-        Thread t = new HarmonyPaletteDelayedNames();
+        Thread t = new HarmonyPaletteDelayedNames(paletteList);
         t.start();
         Log.d("Harmony palettes", "Test after");
     }

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -84,7 +84,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         //Lets show the chosen color and its complement
         float[][] testBasicColor = HarmonyGenerator.complementScheme(hue, saturation, value, 2);
         ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 2);
-        MyPalette testBasicPalette = new MyPalette("1", "Analogous", testBasicColorMyColors);
+        MyPalette testBasicPalette = new MyPalette("1", "Color & Complement", testBasicColorMyColors);
         paletteList.add(testBasicPalette);
 
         //Testing getting the analogous colors each a # of degrees to each side of the given color.

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -130,6 +130,15 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         }
 
         //Now that we have the palettes, we can add names asynchronously?
+        //Doesn't work in our version of Java
+//        Thread newThread = new Thread(() -> {
+//            Log.d("Harmony", "Test thread");
+//        });
+//        newThread.start();
+        Log.d("Harmony palettes", "Test before");
+        Thread t = new HarmonyPaletteDelayedNames();
+        t.start();
+        Log.d("Harmony palettes", "Test after");
     }
 
     public void initRecycler(){

--- a/app/src/main/java/com/harmony/livecolor/HarmonyPaletteDelayedNames.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyPaletteDelayedNames.java
@@ -1,16 +1,31 @@
 package com.harmony.livecolor;
 
 import android.util.Log;
+import java.util.ArrayList;
 
 public class HarmonyPaletteDelayedNames extends Thread {
 
+    ArrayList<MyPalette> paletteList;
+
+    public HarmonyPaletteDelayedNames(ArrayList<MyPalette> paletteListArr) {
+        paletteList = paletteListArr;
+    }
+
     @Override
     public void run() {
-        String name = ColorNameGetterCSV.getName("#FFFFFF");
+        //String name = ColorNameGetterCSV.getName("#FFFFFF");
         //(Test to make sure this doesn't freeze up the app.)
-        for(int i = 0; i < 100; ++i){
-            name = ColorNameGetterCSV.getName("#FFFFFF");
+//        for(int i = 0; i < 100; ++i){
+//            name = ColorNameGetterCSV.getName("#FFFFFF");
+//        }
+        Log.d("Harmony palettes", "Inside thread. Entering loop");
+        for(MyPalette pal : paletteList){
+            for(MyColor color : pal.getColors()){
+                String name = ColorNameGetterCSV.getName(color.getHex());
+                color.setName(name);
+            }
         }
-        Log.d("Harmony palettes", "Inside thread. "+name);
+
+        Log.d("Harmony palettes", "Inside thread. Done");
     }
 }

--- a/app/src/main/java/com/harmony/livecolor/HarmonyPaletteDelayedNames.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyPaletteDelayedNames.java
@@ -3,6 +3,10 @@ package com.harmony.livecolor;
 import android.util.Log;
 import java.util.ArrayList;
 
+/**
+ * Class for HarmonyInfoActivity.java to use to load color names for many palettes without freezing up the app.
+ * @author Dustin
+ */
 public class HarmonyPaletteDelayedNames extends Thread {
 
     ArrayList<MyPalette> paletteList;
@@ -13,11 +17,6 @@ public class HarmonyPaletteDelayedNames extends Thread {
 
     @Override
     public void run() {
-        //String name = ColorNameGetterCSV.getName("#FFFFFF");
-        //(Test to make sure this doesn't freeze up the app.)
-//        for(int i = 0; i < 100; ++i){
-//            name = ColorNameGetterCSV.getName("#FFFFFF");
-//        }
         Log.d("Harmony palettes", "Inside thread. Entering loop");
         for(MyPalette pal : paletteList){
             for(MyColor color : pal.getColors()){

--- a/app/src/main/java/com/harmony/livecolor/HarmonyPaletteDelayedNames.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyPaletteDelayedNames.java
@@ -1,0 +1,16 @@
+package com.harmony.livecolor;
+
+import android.util.Log;
+
+public class HarmonyPaletteDelayedNames extends Thread {
+
+    @Override
+    public void run() {
+        String name = ColorNameGetterCSV.getName("#FFFFFF");
+        //(Test to make sure this doesn't freeze up the app.)
+        for(int i = 0; i < 100; ++i){
+            name = ColorNameGetterCSV.getName("#FFFFFF");
+        }
+        Log.d("Harmony palettes", "Inside thread. "+name);
+    }
+}


### PR DESCRIPTION
Added code to support not generating redundant colors, primarily for black and white. #35
Added the color's complement to a palette. 
Fixed minor errors, added documentation. 
Loads color names asyncronously to avoid freezing up the app. #55

Known bugs: 
Quickly opening a palette will result in the names not being loaded. Not a big deal, they can still see the name by going to color info.
HSV has some rounding errors. The user might notice that their color's hex in the color info window and on the harmony page is different. Annoying, not sure how to fix. #23 