### PR TITLE
Merge last part of bugfix for #29

### DIFF
--- a/app/src/main/java/com/harmony/livecolor/ColorNameGetterCSV.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorNameGetterCSV.java
@@ -29,6 +29,7 @@ public class ColorNameGetterCSV extends android.app.Application {
     private static ArrayList<String[]> colorNames;
     //Hex -> Name
     private static Map<String, String> colorCache;
+    private static int cacheLength;
     //This might be redundant? Whatever.
     private static boolean haveAlreadyReadNames;
     //If for some reason the csv changes format, you can change these and it all should still work.
@@ -154,7 +155,7 @@ public class ColorNameGetterCSV extends android.app.Application {
 
         //Check if we have this hex value cached. If so, we don't need to loop through the whole thing, we already know the name.
         if(colorCache.get(hex) != null){
-            Log.d("colorname I76", "Found hex "+hex+" in cache, "+colorCache.get(hex));
+            Log.d("colorname I76", "("+cacheLength+") Found hex "+hex+" in cache, "+colorCache.get(hex));
             return colorCache.get(hex);
         }
 
@@ -242,7 +243,10 @@ public class ColorNameGetterCSV extends android.app.Application {
         InputStream inputStream = null;
         ColorNameGetterCSV colors = new ColorNameGetterCSV(inputStream);
         String name = colors.searchForName(hex);
+
         colorCache.put(hex, name);
+        ++cacheLength;
+
         return name;
     }
 

--- a/app/src/main/java/com/harmony/livecolor/ColorNameGetterCSV.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorNameGetterCSV.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 //Credit for color names:
 //https://github.com/meodai/color-names
@@ -25,6 +27,8 @@ public class ColorNameGetterCSV extends android.app.Application {
 
     private InputStream inputStream;
     private static ArrayList<String[]> colorNames;
+    //Hex -> Name
+    private static Map<String, String> colorCache;
     //This might be redundant? Whatever.
     private static boolean haveAlreadyReadNames;
     //If for some reason the csv changes format, you can change these and it all should still work.
@@ -99,6 +103,9 @@ public class ColorNameGetterCSV extends android.app.Application {
     public void readColors(){
         this.colorNames = this.read();
         this.haveAlreadyReadNames = true;
+        //TODO not sure about this. Arbitrary number.
+        final int INITIAL_CACHE_CAPACITY = 1024;
+        this.colorCache = new ConcurrentHashMap<String, String>(INITIAL_CACHE_CAPACITY);
         //printArr();
     }
 
@@ -143,6 +150,12 @@ public class ColorNameGetterCSV extends android.app.Application {
             } else {
                 this.readColors();
             }
+        }
+
+        //Check if we have this hex value cached. If so, we don't need to loop through the whole thing, we already know the name.
+        if(colorCache.get(hex) != null){
+            Log.d("colorname I76", "Found hex "+hex+" in cache, "+colorCache.get(hex));
+            return colorCache.get(hex);
         }
 
         //Use the list of names, finds the nearest
@@ -228,7 +241,9 @@ public class ColorNameGetterCSV extends android.app.Application {
     public static String getName(String hex){
         InputStream inputStream = null;
         ColorNameGetterCSV colors = new ColorNameGetterCSV(inputStream);
-        return colors.searchForName(hex);
+        String name = colors.searchForName(hex);
+        colorCache.put(hex, name);
+        return name;
     }
 
     //TODO mess around more with library functions? https://developer.android.com/reference/android/widget/TextView#setAutoSizeTextTypeUniformWithConfiguration(int,%20int,%20int,%20int)

--- a/app/src/main/java/com/harmony/livecolor/ColorNameGetterCSV.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorNameGetterCSV.java
@@ -29,7 +29,6 @@ public class ColorNameGetterCSV extends android.app.Application {
     private static ArrayList<String[]> colorNames;
     //Hex -> Name
     private static Map<String, String> colorCache;
-    private static int cacheLength;
     //This might be redundant? Whatever.
     private static boolean haveAlreadyReadNames;
     //If for some reason the csv changes format, you can change these and it all should still work.
@@ -155,7 +154,7 @@ public class ColorNameGetterCSV extends android.app.Application {
 
         //Check if we have this hex value cached. If so, we don't need to loop through the whole thing, we already know the name.
         if(colorCache.get(hex) != null){
-            Log.d("colorname I76", "("+cacheLength+") Found hex "+hex+" in cache, "+colorCache.get(hex));
+            Log.d("colorname I76", "Found hex "+hex+" in cache, "+colorCache.get(hex));
             return colorCache.get(hex);
         }
 
@@ -245,7 +244,6 @@ public class ColorNameGetterCSV extends android.app.Application {
         String name = colors.searchForName(hex);
 
         colorCache.put(hex, name);
-        ++cacheLength;
 
         return name;
     }

--- a/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
@@ -559,6 +559,19 @@ public class ColorPickerFragment extends Fragment implements SaveListener {
     }
 
     @Override
+    public void onResume() {
+        Log.d("Lifecycles", "onResume: ColorPicker resumed");
+
+        //If we find the color in the DB already, fill in the bookmark
+        int colorInt = colorT;
+        if(findPixelInDatabase(colorInt, colorDB)){
+            fillInBookmark(colorInt);
+        }
+
+        super.onResume();
+    }
+
+    @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         Log.d("Lifecycles", "onViewCreated: View Created for Color Picker Fragment");
         loadColorView();


### PR DESCRIPTION
Fix for #29 when pressing back button after saving a color in Edit or Info, fills in the bookmark.

Known bugs: This won't work with saving in harmonies, because of rounding and because I didn't change anything in ColorInfo. 