### PR TITLE
Constraint ui

### DIFF
--- a/app/src/main/java/com/harmony/livecolor/CustomDialog.java
+++ b/app/src/main/java/com/harmony/livecolor/CustomDialog.java
@@ -285,10 +285,17 @@ public class CustomDialog implements SaveDialogRecyclerViewAdapter.OnListFragmen
             }
         });
 
+        builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.cancel();
+            }
+        });
+
 
         alertDialogName = builder.create();
         alertDialogName.show();
         alertDialogName.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(Color.parseColor(AccentUtils.getAccent(context)));
+        alertDialogName.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(Color.parseColor(AccentUtils.getAccent(context)));
     }
 
     /**

--- a/app/src/main/res/layout/fragment_color_picker.xml
+++ b/app/src/main/res/layout/fragment_color_picker.xml
@@ -10,6 +10,7 @@
     android:weightSum="10"
     tools:context=".ColorPickerFragment">
 
+
     <FrameLayout
         android:id="@+id/frameLayoutImageView"
         android:layout_width="0dp"
@@ -40,7 +41,7 @@
             android:src="@drawable/add_image" />
 
     </FrameLayout>
-    
+
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayoutBottom"
@@ -98,13 +99,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline2"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:layout_constraintGuide_percent=".55" />
 
                 <TextView
                     android:id="@+id/colorName"
@@ -178,6 +172,13 @@
                     android:visibility="gone"
                     tools:layout_editor_absoluteX="8dp"
                     tools:layout_editor_absoluteY="8dp" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    app:layout_constraintGuide_percent=".55" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             //below gets our HEX/RGB/HSV without labels
@@ -191,22 +192,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/guideline">
-
-                <androidx.appcompat.widget.AppCompatImageButton
-                    android:id="@+id/infoButton"
-                    style="@android:style/Widget.DeviceDefault.ImageButton"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:adjustViewBounds="true"
-                    android:background="@android:color/transparent"
-                    android:padding="10dp"
-                    android:scaleType="fitCenter"
-                    android:src="@drawable/info_filled"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@+id/editButton"
-                    app:layout_constraintHorizontal_bias="0.5"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
 
                 <ImageButton
                     android:id="@+id/editButton"
@@ -237,6 +222,22 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.5"
                     app:layout_constraintStart_toEndOf="@+id/editButton"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/infoButton"
+                    style="@android:style/Widget.DeviceDefault.ImageButton"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:adjustViewBounds="true"
+                    android:background="@android:color/transparent"
+                    android:padding="10dp"
+                    android:scaleType="fitCenter"
+                    android:src="@drawable/info_filled"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/editButton"
+                    app:layout_constraintHorizontal_bias="0.5"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowBackground">@drawable/livecolor_logo_splash_dark</item>
+        <item name="android:windowBackground">@drawable/livecolor_logo_2</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:adjustViewBounds">true</item>
     </style>


### PR DESCRIPTION
adding two small things:
- Splash now listens to device, rather than just stuck in one state
- There is a cancel button on the new/rename palette dialog
