### PR TITLE
Max zoom setting, max palette size, and some misc harmony fixes. 

### DIFF
--- a/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
@@ -36,6 +36,8 @@ public class ColorDatabase extends SQLiteOpenHelper {
     public static final String PAL2 = "NAME"; //PALETTE NAME
     public static final String PAL3 = "REF"; //String containing all IDs of colors in palette, separated by spaces
 
+    public final static int MAX_COLORS_PER_PALETTE = 3;//TODO make this much larger after testing
+
     final String TAG_COLOR = "ColorDatabase";
     final String TAG_PALETTE = "PaletteDatabase";
 
@@ -197,8 +199,14 @@ public class ColorDatabase extends SQLiteOpenHelper {
     }
 
     //Based on doesPaletteHaveColor
-    //TODO comment
-    //TODO test more
+
+    /**
+     * Simply gets the number of colors in a given palette.
+     *
+     * @param paletteId
+     * @return Number of colors in the palette
+     * @author Dustin
+     */
     //TODO undo save bookmark if it didn't go? Eh. Minor issue. Could just make a toast? Current toast claims color already exists, fix that.
     public int numColorsInPalette(String paletteId){
         db = this.getWritableDatabase();
@@ -229,31 +237,32 @@ public class ColorDatabase extends SQLiteOpenHelper {
      */
     public boolean addColorToPalette(String paletteId, String colorId) {
         db = this.getWritableDatabase();
-        Log.d(TAG_PALETTE, "addPaletteInfoData: id of color added to new palette = " + colorId);
-        //check if the color is already in the palette, if not
-        //Also only adds if it's below this limit
-        final int MAX_COLORS_PER_PALETTE = 3;//TODO make this much larger after testing
-        if(!doesPaletteHaveColor(paletteId,colorId) && numColorsInPalette(paletteId) <= MAX_COLORS_PER_PALETTE) {
-            //update the palette ref string to include the new color id
-            String paletteColors = getPaletteColors(paletteId);
-            Log.d(TAG_PALETTE, "addColorToPalette: paletteColors before = " + paletteColors);
-            //each color should ALWAYS have a space before it for searching
-            String newPaletteColors = paletteColors.concat(colorId + " ");
-            String updateQuery = "UPDATE " + PALETTE_TABLE_NAME
-                    + " SET REF = \'" + newPaletteColors + "\'"
-                    + " WHERE ID = \'" + paletteId + "\'";
-            try {
-                db.execSQL(updateQuery);
-                Log.d(TAG_PALETTE, "addColorToPalette: paletteColors after = " + paletteColors);
-                return true;
-            }
-            catch (SQLException e) {
-                e.printStackTrace();
-                return false;
-            }
+        Log.d(TAG_PALETTE, "addPaletteInfoData: id of color adding to new palette = " + colorId);
+        //Check if the color is already in the palette or if the palette is full
+        if(doesPaletteHaveColor(paletteId,colorId)){
+            Log.d(TAG_PALETTE, "addPaletteInfoData: color already existed");
+            return false;
+        } else if (numColorsInPalette(paletteId) >= MAX_COLORS_PER_PALETTE){
+            Log.d(TAG_PALETTE, "addPaletteInfoData: palette full");
+            return false;
         }
-        Log.d(TAG_PALETTE, "addPaletteInfoData: color already existed");
-        return false;
+        //update the palette ref string to include the new color id
+        String paletteColors = getPaletteColors(paletteId);
+        Log.d(TAG_PALETTE, "addColorToPalette: paletteColors before = " + paletteColors);
+        //each color should ALWAYS have a space before it for searching
+        String newPaletteColors = paletteColors.concat(colorId + " ");
+        String updateQuery = "UPDATE " + PALETTE_TABLE_NAME
+                + " SET REF = \'" + newPaletteColors + "\'"
+                + " WHERE ID = \'" + paletteId + "\'";
+        try {
+            db.execSQL(updateQuery);
+            Log.d(TAG_PALETTE, "addColorToPalette: paletteColors after = " + paletteColors);
+            return true;
+        }
+        catch (SQLException e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     /**

--- a/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
@@ -196,6 +196,23 @@ public class ColorDatabase extends SQLiteOpenHelper {
         }
     }
 
+    //Based on doesPaletteHaveColor
+    //TODO comment
+    //TODO test
+    public int numColorsInPalette(String paletteId){
+        db = this.getWritableDatabase();
+        String selectQuery = "SELECT Count(*) FROM " + PALETTE_TABLE_NAME
+                + " WHERE ID = \'" + paletteId + "\'";
+        Cursor paletteData = db.rawQuery(selectQuery, null);
+        Log.d(TAG_PALETTE,"numColorsInPalette: Results = " + paletteData + " " + (paletteData.moveToFirst()));
+        int numColors = 0;
+        if(paletteData != null){
+            numColors = paletteData.getCount();
+        }
+        Log.d("I102", "palette had "+numColors+" colors");
+        return numColors;
+    }
+
     /**
      * CALL FOR ADDING COLOR TO PALETTE (CHECKS IF COLOR ALREADY EXISTS IN PALETTE) (DONE)
      * add a color existing in the color database to an existing palette if not already in the palette
@@ -207,7 +224,9 @@ public class ColorDatabase extends SQLiteOpenHelper {
         db = this.getWritableDatabase();
         Log.d(TAG_PALETTE, "addPaletteInfoData: id of color added to new palette = " + colorId);
         //check if the color is already in the palette, if not
-        if(!doesPaletteHaveColor(paletteId,colorId)) {
+        //Also only adds if it's below this limit
+        final int MAX_COLORS_PER_PALETTE = 3;//TODO make this much larger after testing
+        if(!doesPaletteHaveColor(paletteId,colorId) && numColorsInPalette(paletteId) <= MAX_COLORS_PER_PALETTE) {
             //update the palette ref string to include the new color id
             String paletteColors = getPaletteColors(paletteId);
             Log.d(TAG_PALETTE, "addColorToPalette: paletteColors before = " + paletteColors);

--- a/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
@@ -36,7 +36,7 @@ public class ColorDatabase extends SQLiteOpenHelper {
     public static final String PAL2 = "NAME"; //PALETTE NAME
     public static final String PAL3 = "REF"; //String containing all IDs of colors in palette, separated by spaces
 
-    public final static int MAX_COLORS_PER_PALETTE = 3;//TODO make this much larger after testing
+    public final static int MAX_COLORS_PER_PALETTE = 2048;
 
     final String TAG_COLOR = "ColorDatabase";
     final String TAG_PALETTE = "PaletteDatabase";

--- a/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
@@ -207,7 +207,7 @@ public class ColorDatabase extends SQLiteOpenHelper {
      * @return Number of colors in the palette
      * @author Dustin
      */
-    //TODO undo save bookmark if it didn't go? Eh. Minor issue. Could just make a toast? Current toast claims color already exists, fix that.
+    //TODO Current toast claims color already exists, fix that.
     public int numColorsInPalette(String paletteId){
         db = this.getWritableDatabase();
         String selectQuery = "SELECT * FROM " + PALETTE_TABLE_NAME

--- a/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
@@ -198,16 +198,23 @@ public class ColorDatabase extends SQLiteOpenHelper {
 
     //Based on doesPaletteHaveColor
     //TODO comment
-    //TODO test
+    //TODO test more
+    //TODO undo save bookmark if it didn't go? Eh. Minor issue. Could just make a toast? Current toast claims color already exists, fix that.
     public int numColorsInPalette(String paletteId){
         db = this.getWritableDatabase();
-        String selectQuery = "SELECT Count(*) FROM " + PALETTE_TABLE_NAME
+        String selectQuery = "SELECT * FROM " + PALETTE_TABLE_NAME
                 + " WHERE ID = \'" + paletteId + "\'";
         Cursor paletteData = db.rawQuery(selectQuery, null);
         Log.d(TAG_PALETTE,"numColorsInPalette: Results = " + paletteData + " " + (paletteData.moveToFirst()));
         int numColors = 0;
         if(paletteData != null){
-            numColors = paletteData.getCount();
+            //TODO is this anywhere else? Or can I do it by column name?
+            final int COLOR_ID_INDEX = 2;
+            String colorIDs = paletteData.getString(COLOR_ID_INDEX);
+            //Split on whitespace
+            //https://stackoverflow.com/questions/7899525/how-to-split-a-string-by-space
+            numColors = colorIDs.trim().split("\\s+").length;
+            Log.d("I102", "pd had "+paletteData.getString(COLOR_ID_INDEX));
         }
         Log.d("I102", "palette had "+numColors+" colors");
         return numColors;

--- a/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorDatabase.java
@@ -207,7 +207,6 @@ public class ColorDatabase extends SQLiteOpenHelper {
      * @return Number of colors in the palette
      * @author Dustin
      */
-    //TODO Current toast claims color already exists, fix that.
     public int numColorsInPalette(String paletteId){
         db = this.getWritableDatabase();
         String selectQuery = "SELECT * FROM " + PALETTE_TABLE_NAME

--- a/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
@@ -279,12 +279,16 @@ public class ColorPickerFragment extends Fragment implements SaveListener {
         pickingImage.setOnTouchListener(handleTouch);
 
         //Sets the maximum zoom for the touchview
-        //TODO this should probably only be set once, or detect something about the image (resolution?) and work based on that when the image is loaded.
-        final float DEFAULT_MAX_ZOOM_MULT = 100;
+        //TODO this should probably be in a function, needs to be re-checked in onResume.
+        final int DEFAULT_MAX_ZOOM_MULT = 100;
         com.ortiz.touchview.TouchImageView touchView = rootView.findViewById(R.id.pickingImage);
         if(touchView != null) {
-            touchView.setMaxZoom(DEFAULT_MAX_ZOOM_MULT);
-            Log.d("I100", "TouchView max zoom set");
+            //Read setting, or use default if it fails.
+            SharedPreferences prefs = getContext().getSharedPreferences("prefs", MODE_PRIVATE);
+            int maxZoom = prefs.getInt("maxZoom", DEFAULT_MAX_ZOOM_MULT);
+            //TODO technically this can take a float. Allow user to set floats?
+            touchView.setMaxZoom(maxZoom);
+            Log.d("I100", "TouchView max zoom set to "+maxZoom);
         } else {
             Log.d("I100", "TouchView was null");
         }

--- a/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
@@ -86,6 +86,7 @@ public class ColorPickerFragment extends Fragment implements SaveListener {
     private static final int CAMERA_OR_GALLERY = 0;
     private static final int RESULT_LOAD_IMAGE = 1;
     private static final int IMAGE_CAPTURE_CODE = 1001;
+    public static final int DEFAULT_MAX_ZOOM_MULT = 15;
     //Text displayed as color name if you click on the background
     private static final String BACKGROUND_COLOR_TEXT = "Background";
     private final static double MAX_TEXTVIEW_WIDTH_PERCENT = 0.60;
@@ -279,8 +280,6 @@ public class ColorPickerFragment extends Fragment implements SaveListener {
         pickingImage.setOnTouchListener(handleTouch);
 
         //Sets the maximum zoom for the touchview
-        //TODO this should probably be in a function, needs to be re-checked in onResume.
-        final int DEFAULT_MAX_ZOOM_MULT = 100;
         com.ortiz.touchview.TouchImageView touchView = rootView.findViewById(R.id.pickingImage);
         if(touchView != null) {
             //Read setting, or use default if it fails.

--- a/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/ColorPickerFragment.java
@@ -277,6 +277,18 @@ public class ColorPickerFragment extends Fragment implements SaveListener {
         }
         //Adds a listener to get the x and y coordinates of taps and update the display
         pickingImage.setOnTouchListener(handleTouch);
+
+        //Sets the maximum zoom for the touchview
+        //TODO this should probably only be set once, or detect something about the image (resolution?) and work based on that when the image is loaded.
+        final float DEFAULT_MAX_ZOOM_MULT = 100;
+        com.ortiz.touchview.TouchImageView touchView = rootView.findViewById(R.id.pickingImage);
+        if(touchView != null) {
+            touchView.setMaxZoom(DEFAULT_MAX_ZOOM_MULT);
+            Log.d("I100", "TouchView max zoom set");
+        } else {
+            Log.d("I100", "TouchView was null");
+        }
+
         return rootView;
     }
 
@@ -431,10 +443,6 @@ public class ColorPickerFragment extends Fragment implements SaveListener {
                     Log.d("DEBUG S2US2 pinchzoom", "Bitmap was non-null, but had error: " + e);
                 }
             }
-
-            //TODO this should probably only be set once, or detect something about the image (resolution?) and work based on that when the image is loaded.
-            final float MAX_ZOOM_MULT = 100;
-            touchView.setMaxZoom(MAX_ZOOM_MULT);
 
 
 

--- a/app/src/main/java/com/harmony/livecolor/CustomDialog.java
+++ b/app/src/main/java/com/harmony/livecolor/CustomDialog.java
@@ -312,12 +312,11 @@ public class CustomDialog implements SaveDialogRecyclerViewAdapter.OnListFragmen
         if(colorDB.addColorToPalette(palette.getId(),Long.toString(colorId))) {
             alertDialogSave.dismiss();
             makeToast("Color has been saved to \"" + palette.getName() + "\"", context);
+            //Tell the listener that it's saved, so it can fill in the save button.
+            notifySaveCompleted();
         } else {
             alertDialogSave.dismiss();
             makeToast("This color already exists in \"" + palette.getName() + "\"", context);
         }
-
-        //Tell the listener that it's saved, so it can fill in the save button.
-        notifySaveCompleted();
     }
 }

--- a/app/src/main/java/com/harmony/livecolor/CustomDialog.java
+++ b/app/src/main/java/com/harmony/livecolor/CustomDialog.java
@@ -316,7 +316,17 @@ public class CustomDialog implements SaveDialogRecyclerViewAdapter.OnListFragmen
             notifySaveCompleted();
         } else {
             alertDialogSave.dismiss();
-            makeToast("This color already exists in \"" + palette.getName() + "\"", context);
+            //Two reasons that function might return false:
+            //1. Palette already has the color
+            //2. Palette is full
+            if(colorDB.doesPaletteHaveColor(palette.getId(), Long.toString(colorId))){
+                makeToast("This color already exists in \"" + palette.getName() + "\"", context);
+            } else if (colorDB.numColorsInPalette(palette.getId()) >= ColorDatabase.MAX_COLORS_PER_PALETTE) {
+                makeToast("This palette is full", context);
+            } else {
+                makeToast("Unknown error", context);
+                Log.w("CustomDialog", "Unknown error while saving to existing palette");
+            }
         }
     }
 }

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -115,7 +115,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         MyPalette testMonochromaticPalette = new MyPalette("2", "Monochromatic", testMonochromaticMyColors);
         paletteList.add(testMonochromaticPalette);
 
-        if(1 - valueTooMonotonous >= value && valueTooMonotonous <= value) {
+        if(valueTooMonotonous <= value && ((1 - valueTooMonotonous >= value) || saturation >= 1)) {
             //TODO (refactor) I may have misunderstood triadic. I can just use the evenly spaced for that. This is Split-Complementary.
             float[][] testTriadic = HarmonyGenerator.triadicScheme(hue, saturation, value, 20, 3);
             ArrayList<MyColor> testTriadicMyColors = HarmonyGenerator.colorsToMyColors(testTriadic, 3);

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -86,11 +86,11 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         //So if it's super light/dark I'll just not generate them.
         float valueTooMonotonous = (float) 0.01;
 
-        boolean valueIsBlackSoDoNotGenerateHueChanges = valueTooMonotonous <= value;
-        boolean valueIsWhiteSoDoNotGenerateHueChanges = ((1 - valueTooMonotonous >= value) || saturation >= 0.01);
+        boolean valueIsNotBlackSoGenerateHueChanges = valueTooMonotonous <= value;
+        boolean valueIsNotWhiteSoGenerateHueChanges = ((1 - valueTooMonotonous >= value) || saturation >= 0.01);
 
         //Check if it's in the range [0.01..0.99] inclusive, or if the value is not small and has saturation.
-        if(valueIsBlackSoDoNotGenerateHueChanges && valueIsWhiteSoDoNotGenerateHueChanges) {
+        if(valueIsNotBlackSoGenerateHueChanges && valueIsNotWhiteSoGenerateHueChanges) {
             //Color & Complement
             float[][] testBasicColor = HarmonyGenerator.complementScheme(hue, saturation, value, 2);
             ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 2);
@@ -118,7 +118,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         MyPalette testMonochromaticPalette = new MyPalette("2", "Monochromatic", testMonochromaticMyColors);
         paletteList.add(testMonochromaticPalette);
 
-        if(valueIsBlackSoDoNotGenerateHueChanges && valueIsWhiteSoDoNotGenerateHueChanges) {
+        if(valueIsNotBlackSoGenerateHueChanges && valueIsNotWhiteSoGenerateHueChanges) {
             //TODO (refactor) I may have misunderstood triadic. I can just use the evenly spaced for that. This is Split-Complementary.
             float[][] testTriadic = HarmonyGenerator.triadicScheme(hue, saturation, value, 20, 3);
             ArrayList<MyColor> testTriadicMyColors = HarmonyGenerator.colorsToMyColors(testTriadic, 3);

--- a/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
+++ b/app/src/main/java/com/harmony/livecolor/HarmonyInfoActivity.java
@@ -86,8 +86,11 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         //So if it's super light/dark I'll just not generate them.
         float valueTooMonotonous = (float) 0.01;
 
+        boolean valueIsBlackSoDoNotGenerateHueChanges = valueTooMonotonous <= value;
+        boolean valueIsWhiteSoDoNotGenerateHueChanges = ((1 - valueTooMonotonous >= value) || saturation >= 0.01);
+
         //Check if it's in the range [0.01..0.99] inclusive, or if the value is not small and has saturation.
-        if(valueTooMonotonous <= value && ((1 - valueTooMonotonous >= value) || saturation >= 1)) {
+        if(valueIsBlackSoDoNotGenerateHueChanges && valueIsWhiteSoDoNotGenerateHueChanges) {
             //Color & Complement
             float[][] testBasicColor = HarmonyGenerator.complementScheme(hue, saturation, value, 2);
             ArrayList<MyColor> testBasicColorMyColors = HarmonyGenerator.colorsToMyColors(testBasicColor, 2);
@@ -115,7 +118,7 @@ public class HarmonyInfoActivity extends AppCompatActivity {
         MyPalette testMonochromaticPalette = new MyPalette("2", "Monochromatic", testMonochromaticMyColors);
         paletteList.add(testMonochromaticPalette);
 
-        if(valueTooMonotonous <= value && ((1 - valueTooMonotonous >= value) || saturation >= 1)) {
+        if(valueIsBlackSoDoNotGenerateHueChanges && valueIsWhiteSoDoNotGenerateHueChanges) {
             //TODO (refactor) I may have misunderstood triadic. I can just use the evenly spaced for that. This is Split-Complementary.
             float[][] testTriadic = HarmonyGenerator.triadicScheme(hue, saturation, value, 20, 3);
             ArrayList<MyColor> testTriadicMyColors = HarmonyGenerator.colorsToMyColors(testTriadic, 3);

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -38,6 +38,7 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 
 import static android.content.Context.MODE_PRIVATE;
+import static com.harmony.livecolor.ColorPickerFragment.DEFAULT_MAX_ZOOM_MULT;
 import static com.harmony.livecolor.UsefulFunctions.makeToast;
 
 public class SettingsGeneralFragment extends  Fragment{
@@ -199,6 +200,14 @@ public class SettingsGeneralFragment extends  Fragment{
             Log.w("I100", "EditZoom was null");
             return;
         }
+        //Loads and adds hint to textbox with previous zoom level
+        SharedPreferences prefs = getContext().getSharedPreferences("prefs", MODE_PRIVATE);
+        int maxZoom = prefs.getInt("maxZoom", DEFAULT_MAX_ZOOM_MULT);
+        editZoom.setHint(""+maxZoom);
+
+        //TODO some keyboards might not work right with this method? Test better.
+        //TODO if you go back without pressing enter should it save? Maybe. Probably not. If we have keyboard issues with the listener then we can.
+        //Set up listener for pressing Enter (saves the setting).
         editZoom.setOnKeyListener(new View.OnKeyListener() {
             public boolean onKey(View v, int keyCode, KeyEvent event) {
                 // If the event is a key-down event on the "enter" button
@@ -207,9 +216,6 @@ public class SettingsGeneralFragment extends  Fragment{
                     // Perform action on key press:
 
                     //Uses shared preferences to store this number, and it will be loaded in ColorPickerFragment
-                    //TODO if you go back without pressing enter should it save?
-                    //TODO load and prefill with previous zoom level when bringing up settings
-                    //TODO some keyboards might not work right with this method? Test better.
                     SharedPreferences preferences = getActivity().getSharedPreferences("prefs", Context.MODE_PRIVATE);
                     SharedPreferences.Editor editor = preferences.edit();
                     final int MINIMUM_ZOOM_LEVEL = 1;

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -215,13 +215,13 @@ public class SettingsGeneralFragment extends  Fragment{
                         (keyCode == KeyEvent.KEYCODE_ENTER)) {
                     // Perform action on key press:
 
-                    //Uses shared preferences to store this number, and it will be loaded in ColorPickerFragment
-                    SharedPreferences preferences = getActivity().getSharedPreferences("prefs", Context.MODE_PRIVATE);
-                    SharedPreferences.Editor editor = preferences.edit();
-                    final int MINIMUM_ZOOM_LEVEL = 1;
-                    int input;
+                    //Try to process the number in the EditText.
                     try {
-                        input = Integer.parseInt(editZoom.getText().toString());
+                        //Uses shared preferences to store this number, and it will be loaded in ColorPickerFragment
+                        SharedPreferences preferences = getActivity().getSharedPreferences("prefs", Context.MODE_PRIVATE);
+                        SharedPreferences.Editor editor = preferences.edit();
+                        final int MINIMUM_ZOOM_LEVEL = 1;
+                        int input = Integer.parseInt(editZoom.getText().toString());
                         if(input < MINIMUM_ZOOM_LEVEL){
                             input = MINIMUM_ZOOM_LEVEL;
                         }

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -14,6 +14,7 @@ import android.text.InputType;
 import android.text.Spanned;
 import android.text.TextWatcher;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,6 +45,7 @@ public class SettingsGeneralFragment extends  Fragment{
     ImageButton imageButtonResetImage;
     RotateAnimation rotate;
     ImageButton imageButtonBack;
+    EditText editZoom;
 
     public SettingsGeneralFragment() {
         // Required empty public constructor
@@ -93,6 +95,7 @@ public class SettingsGeneralFragment extends  Fragment{
 
         imageButtonResetImage = rootView.findViewById(R.id.imageButtonImageReset);
         imageButtonBack = rootView.findViewById(R.id.backButton);
+        imageButtonBack = rootView.findViewById(R.id.backButton);
         
         
         imageButtonResetImage.setOnClickListener(new View.OnClickListener() {
@@ -109,6 +112,8 @@ public class SettingsGeneralFragment extends  Fragment{
             }
         });
 
+        editZoom = rootView.findViewById(R.id.editZoom);
+        setupMaxZoom();
 
         return rootView;
     }
@@ -184,6 +189,28 @@ public class SettingsGeneralFragment extends  Fragment{
         SharedPreferences.Editor editor = getContext().getSharedPreferences("prefs", MODE_PRIVATE).edit();
         editor.putString("image", null);
         editor.apply();
+    }
+
+    //https://stackoverflow.com/a/6832095
+    private void setupMaxZoom(){
+        if(editZoom == null){
+            Log.w("I100", "EditZoom was null");
+            return;
+        }
+        editZoom.setOnKeyListener(new View.OnKeyListener() {
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                // If the event is a key-down event on the "enter" button
+                if ((event.getAction() == KeyEvent.ACTION_DOWN) &&
+                        (keyCode == KeyEvent.KEYCODE_ENTER)) {
+                    // Perform action on key press
+                    Log.d("I100", "Enter key pressed while entering zoom number");
+                    //TODO use shared preferences to store this number, and load it in ColorPickerFragment
+                    //TODO pressing enter should close the input
+                    return true;
+                }
+                return false;
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -38,6 +38,7 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 
 import static android.content.Context.MODE_PRIVATE;
+import static com.harmony.livecolor.UsefulFunctions.makeToast;
 
 public class SettingsGeneralFragment extends  Fragment{
 
@@ -208,24 +209,32 @@ public class SettingsGeneralFragment extends  Fragment{
                     //Uses shared preferences to store this number, and it will be loaded in ColorPickerFragment
                     //TODO if you go back without pressing enter should it save?
                     //TODO load and prefill with previous zoom level when bringing up settings
+                    //TODO some keyboards might not work right with this method? Test better.
                     SharedPreferences preferences = getActivity().getSharedPreferences("prefs", Context.MODE_PRIVATE);
                     SharedPreferences.Editor editor = preferences.edit();
-                    int input = 1;
+                    final int MINIMUM_ZOOM_LEVEL = 1;
+                    int input;
                     try {
                         input = Integer.parseInt(editZoom.getText().toString());
+                        if(input < MINIMUM_ZOOM_LEVEL){
+                            input = MINIMUM_ZOOM_LEVEL;
+                        }
+                        Log.d("I100", "Enter key pressed while entering zoom number "+input);
+                        editor.putInt("maxZoom", input);
+                        editor.apply();
                     } catch (NumberFormatException e) {
                         Log.d("I100", "Input was empty");
+                        //We save nothing, no change.
                     }
-                    editor.putInt("maxZoom", input);
-                    editor.apply();
-                    Log.d("I100", "Enter key pressed while entering zoom number. "+input);
                     //Pressing enter hides the keyboard.
                     //https://stackoverflow.com/a/17789187/14337230
                     InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
                     imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
-                    //Gets rid of the blinking cursor showing you're editing the field.
+                    //Gets rid of the blinking cursor showing you're editing the field, and maybe does other stuff? Doesn't seem to work great. Unneeded? TODO
                     v.clearFocus();
-                    //TODO maybe a toast to tell the user the setting was changed?
+
+                    //Notify the user
+                    makeToast("Setting saved", getContext());
 
                     return true;
                 }

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -206,10 +206,16 @@ public class SettingsGeneralFragment extends  Fragment{
 
                     //Uses shared preferences to store this number, and it will be loaded in ColorPickerFragment
                     //TODO if you go back without pressing enter should it save?
+                    //TODO load and prefill with previous zoom level when bringing up settings
                     SharedPreferences preferences = getActivity().getSharedPreferences("prefs", Context.MODE_PRIVATE);
                     SharedPreferences.Editor editor = preferences.edit();
-                    String input = editZoom.getText().toString();
-                    editor.putInt("maxZoom", Integer.parseInt(input));
+                    int input = 1;
+                    try {
+                        input = Integer.parseInt(editZoom.getText().toString());
+                    } catch (NumberFormatException e) {
+                        Log.d("I100", "Input was empty");
+                    }
+                    editor.putInt("maxZoom", input);
                     editor.apply();
                     Log.d("I100", "Enter key pressed while entering zoom number. "+input);
                     //TODO pressing enter should close the input

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -21,6 +21,7 @@ import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.view.animation.LinearInterpolator;
 import android.view.animation.RotateAnimation;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageButton;
@@ -218,8 +219,14 @@ public class SettingsGeneralFragment extends  Fragment{
                     editor.putInt("maxZoom", input);
                     editor.apply();
                     Log.d("I100", "Enter key pressed while entering zoom number. "+input);
-                    //TODO pressing enter should close the input
-                    //https://stackoverflow.com/questions/1109022/how-do-you-close-hide-the-android-soft-keyboard-using-java
+                    //Pressing enter hides the keyboard.
+                    //https://stackoverflow.com/a/17789187/14337230
+                    InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
+                    imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+                    //Gets rid of the blinking cursor showing you're editing the field.
+                    v.clearFocus();
+                    //TODO maybe a toast to tell the user the setting was changed?
+
                     return true;
                 }
                 return false;

--- a/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
+++ b/app/src/main/java/com/harmony/livecolor/SettingsGeneralFragment.java
@@ -202,10 +202,18 @@ public class SettingsGeneralFragment extends  Fragment{
                 // If the event is a key-down event on the "enter" button
                 if ((event.getAction() == KeyEvent.ACTION_DOWN) &&
                         (keyCode == KeyEvent.KEYCODE_ENTER)) {
-                    // Perform action on key press
-                    Log.d("I100", "Enter key pressed while entering zoom number");
-                    //TODO use shared preferences to store this number, and load it in ColorPickerFragment
+                    // Perform action on key press:
+
+                    //Uses shared preferences to store this number, and it will be loaded in ColorPickerFragment
+                    //TODO if you go back without pressing enter should it save?
+                    SharedPreferences preferences = getActivity().getSharedPreferences("prefs", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = preferences.edit();
+                    String input = editZoom.getText().toString();
+                    editor.putInt("maxZoom", Integer.parseInt(input));
+                    editor.apply();
+                    Log.d("I100", "Enter key pressed while entering zoom number. "+input);
                     //TODO pressing enter should close the input
+                    //https://stackoverflow.com/questions/1109022/how-do-you-close-hide-the-android-soft-keyboard-using-java
                     return true;
                 }
                 return false;

--- a/app/src/main/res/layout/fragment_settings_general.xml
+++ b/app/src/main/res/layout/fragment_settings_general.xml
@@ -118,7 +118,6 @@
             android:inputType="number"
             android:ems="10"
             android:fontFamily="@font/lato_regular"
-            android:hint="@string/zoom_choice"
             android:maxLength="5"
             android:textSize="20sp"
             android:theme="@style/PhoAppTheme"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,6 @@
     <string name="github"><u>GitHub</u></string>
     <string name="accent_choice_prompt">Light Mode Accent</string>
     <string name="accent_choice">#86357C</string>
-    <string name="zoom_choice_prompt">Maximum Zoom</string>
-    <string name="zoom_choice">100</string>
+    <string name="zoom_choice_prompt">Maximum Zoom Level</string>
 
 </resources>


### PR DESCRIPTION
Adds a setting under General to change the maximum zoom. #100
Changes default max zoom to 15x. 
Adds a limit to the number of colors per palette. Limit is currently set to 2048 arbitrarily. #102
Some harmony fixes for certain saturation-value combos that weren't generating. 

Known bugs: 
Max zoom setting pressing enter may not work on all devices/keyboards? Needs more testing. 
Colors will be added to db even if palette is full.  #123